### PR TITLE
Fix custom exceptions

### DIFF
--- a/src/main/errors.py
+++ b/src/main/errors.py
@@ -1,23 +1,23 @@
 class ZeroAgentIdError(Exception):
     def __init__(self):
         self.message = "Agent id should not be equal to zero which is the convention for empty cell."
-        Exception.__init__(self, self.message)
+        super().__init__(self.message)
 
 
 class ColumnIsFullError(Exception):
     def __init__(self, col_index):
         self.message = "You cannot play in column {} because it is full.".format(col_index)
-        Exception.__init__(self, self.message)
+        super().__init__(self.message)
 
 
 class OutOfGridError(Exception):
     def __init__(self, agent_id, col_index, nb_cols):
         self.message = "Player {} has selected selected column {} but there are only {} columns"\
             .format(agent_id, col_index, nb_cols)
-        Exception.__init__(self, self.message)
+        super().__init__(self.message)
 
 
 class AlreadyPlayedError(Exception):
     def __init__(self, agent_id):
         self.message = "Player {} has already played, cannot play twice in a row".format(agent_id)
-        Exception.__init__(self, self.message)
+        super().__init__(self.message)

--- a/src/main/errors.py
+++ b/src/main/errors.py
@@ -1,19 +1,23 @@
 class ZeroAgentIdError(Exception):
     def __init__(self):
-        self.message = "Agent id should not be equal zero which is the convention for empty cell."
+        self.message = "Agent id should not be equal to zero which is the convention for empty cell."
+        Exception.__init__(self, self.message)
 
 
 class ColumnIsFullError(Exception):
     def __init__(self, col_index):
         self.message = "You cannot play in column {} because it is full.".format(col_index)
+        Exception.__init__(self, self.message)
 
 
 class OutOfGridError(Exception):
     def __init__(self, agent_id, col_index, nb_cols):
         self.message = "Player {} has selected selected column {} but there are only {} columns"\
             .format(agent_id, col_index, nb_cols)
+        Exception.__init__(self, self.message)
 
 
 class AlreadyPlayedError(Exception):
     def __init__(self, agent_id):
         self.message = "Player {} has already played, cannot play twice in a row".format(agent_id)
+        Exception.__init__(self, self.message)


### PR DESCRIPTION
We did not use the init of the parent class Exception in our custom errors, hence the message displayed was just the argument we passed to instantiate the custom error, not the custom message we designed. This PR fixes this issue by calling the `__init__` method of the parent class with the custom message via the `super` keyword